### PR TITLE
Improved unregister for the case when the whole form is being unmounted

### DIFF
--- a/src/components/ValidationFieldArray.vue
+++ b/src/components/ValidationFieldArray.vue
@@ -76,7 +76,7 @@ function move(from: number, to: number) {
   fields.value.splice(to, 0, fields.value.splice(from, 1)[0]);
 }
 function remove(index: number) {
-  fields.value = fields.value.filter((field, i) => index !== i);
+  fields.value.splice(index, 1);
 }
 
 const onChange: Field['onChange'] = (value: unknown) => {

--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -235,7 +235,8 @@ const register: Register = (fieldComponent) => {
   };
 };
 function unregister(fieldComponent: Field) {
-  fieldComponents.value = fieldComponents.value.filter((field) => field !== fieldComponent);
+  const index = fieldComponents.value.indexOf(fieldComponent);
+  fieldComponents.value.splice(index, 1);
 }
 
 provide(registerSymbol, register);

--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, provide, ref, toRefs, watch } from 'vue';
+import { computed, nextTick, provide, ref, toRefs, watch, onBeforeUnmount } from 'vue';
 
 import type { Values } from '../types/values';
 import type {
@@ -238,6 +238,10 @@ function unregister(fieldComponent: Field) {
   const index = fieldComponents.value.indexOf(fieldComponent);
   fieldComponents.value.splice(index, 1);
 }
+
+onBeforeUnmount(() => {
+  fieldComponents.value = [];
+});
 
 provide(registerSymbol, register);
 provide(validateSymbol, async (name: string) => {

--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -235,7 +235,15 @@ const register: Register = (fieldComponent) => {
   };
 };
 function unregister(fieldComponent: Field) {
+  if (fieldComponents.value.length === 0) {
+    return;
+  }
+
   const index = fieldComponents.value.indexOf(fieldComponent);
+  if (index === -1) {
+    return;
+  }
+
   fieldComponents.value.splice(index, 1);
 }
 


### PR DESCRIPTION
- Use splice instead of filter for unregister to avoid recreation of array
- Clear fields array on ValidationProvider unmount to avoid a lot of operations in unregister which will do the same thing after all

Release-As: 3.0.0-alpha.3