### PR TITLE
[DEV-13517] Добавить флаг во vue-validate-form для настройки сброса полей формы при изменении defaultValues (v2)

### DIFF
--- a/src/components/ValidationProvider.js
+++ b/src/components/ValidationProvider.js
@@ -43,7 +43,8 @@ export default {
       default: 'div'
     },
     resetFieldsAfterUpdate: {
-      type: Boolean
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -179,7 +180,7 @@ export default {
         this.innerDefaultValues = JSON.parse(JSON.stringify(values));
       }
       this.fieldComponents.forEach(({ dirty, reset }) => {
-        if (this.resetFieldsAfterUpdate && dirty) {
+        if (!this.resetFieldsAfterUpdate && dirty) {
           return;
         }
         reset();

--- a/src/components/ValidationProvider.js
+++ b/src/components/ValidationProvider.js
@@ -41,6 +41,9 @@ export default {
     tag: {
       type: String,
       default: 'div'
+    },
+    resetFieldsAfterUpdate: {
+      type: Boolean
     }
   },
   data() {
@@ -176,7 +179,7 @@ export default {
         this.innerDefaultValues = JSON.parse(JSON.stringify(values));
       }
       this.fieldComponents.forEach(({ dirty, reset }) => {
-        if (dirty) {
+        if (this.resetFieldsAfterUpdate && dirty) {
           return;
         }
         reset();

--- a/src/components/ValidationProvider.js
+++ b/src/components/ValidationProvider.js
@@ -175,7 +175,10 @@ export default {
       if (values) {
         this.innerDefaultValues = JSON.parse(JSON.stringify(values));
       }
-      this.fieldComponents.forEach(({ reset }) => {
+      this.fieldComponents.forEach(({ dirty, reset }) => {
+        if (dirty) {
+          return;
+        }
         reset();
       });
     },


### PR DESCRIPTION
Суть: [тред](https://huntflow.slack.com/archives/C02RCGX12JC/p1700561246208549)

Нужно добавить флаг, при наличии которого форма не будет сбрасывать введенные данные после обновления `defaultValues`.
Причина: иногда в попапе пользователь пишет текст, а в notifier'е приходит событие, которое вызывает обновление у `<validation-provider>`, и происходит `reset()`. Но пользователю не нужны эти изменения - он мб уже час там писал новые данные, а мы ему всё сносим.