### PR TITLE
[DEV-13517] Добавить флаг во vue-validate-form для настройки сброса полей формы при изменении defaultValues

### DIFF
--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -43,12 +43,14 @@ interface Props {
   defaultValues?: Values;
   defaultErrors?: ValidationsErrors;
   resolver?: Resolver;
+  resetFieldsAfterUpdate?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   defaultValues: () => ({}),
   defaultErrors: () => ({}),
-  resolver: () => (values: Record<string, unknown>) => ({ values, errors: {} })
+  resolver: () => (values: Record<string, unknown>) => ({ values, errors: {} }),
+  resetFieldsAfterUpdate: true
 });
 const emit = defineEmits<{
   (
@@ -64,7 +66,7 @@ const emit = defineEmits<{
   (e: 'dirty', dirty: boolean): void;
 }>();
 
-const { defaultValues, defaultErrors, resolver } = toRefs(props);
+const { defaultValues, defaultErrors, resolver, resetFieldsAfterUpdate } = toRefs(props);
 
 const submitted = ref(false);
 const innerDefaultValues = ref<Values>({});
@@ -186,8 +188,8 @@ function reset(values?: Values) {
   }
 
   fieldComponents.value.forEach(({ dirty, reset }) => {
-    if (dirty) {
-      return
+    if (resetFieldsAfterUpdate && dirty) {
+      return;
     }
     reset();
   });

--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -188,7 +188,7 @@ function reset(values?: Values) {
   }
 
   fieldComponents.value.forEach(({ dirty, reset }) => {
-    if (resetFieldsAfterUpdate && dirty) {
+    if (!resetFieldsAfterUpdate && dirty) {
       return;
     }
     reset();

--- a/src/components/ValidationProvider.vue
+++ b/src/components/ValidationProvider.vue
@@ -185,7 +185,10 @@ function reset(values?: Values) {
     innerDefaultValues.value = JSON.parse(JSON.stringify(values));
   }
 
-  fieldComponents.value.forEach(({ reset }) => {
+  fieldComponents.value.forEach(({ dirty, reset }) => {
+    if (dirty) {
+      return
+    }
     reset();
   });
 }


### PR DESCRIPTION
Суть: [тред](https://huntflow.slack.com/archives/C02RCGX12JC/p1700561246208549)

Нужно добавить флаг, при наличии которого форма не будет сбрасывать введенные данные после обновления `defaultValues`.
Причина: иногда в попапе пользователь пишет текст, а в notifier'е приходит событие, которое вызывает обновление у `<validation-provider>`, и происходит `reset()`. Но пользователю не нужны эти изменения - он мб уже час там писал новые данные, а мы ему всё сносим.